### PR TITLE
[반재영] 카테고리 링크 연결, 햄버거메뉴 수정, 헤더 반응형 수정

### DIFF
--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import CategoryBox from "../home/CategoryBox";
 import HamburgerMenu from "../home/HamburgerMenu";
 import MainIconButton from "../home/MainIconButton";
@@ -5,10 +7,14 @@ import MainLogo from "../home/MainLogo";
 import ScrollButton from "../home/ScrollButton";
 
 function Header() {
+  const[isOpen, setIsOpen] = useState(false)
+  
+  const toggleMenu = () => setIsOpen(!isOpen)
+
   return (
-    <header className="flex justify-center">
+    <header className={`w-full justify-center ${isOpen? "bg-white fixed z-10": "bg-none flex"}`}>
       <nav className="pt-6 flex h-[190px] w-full items-center justify-between px-10 desktop:w-[1440px]">
-        <HamburgerMenu />
+        <HamburgerMenu isOpen={isOpen} toggleMenu={toggleMenu}/>
         <MainLogo />
         <CategoryBox />
         <MainIconButton />

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -7,7 +7,7 @@ import ScrollButton from "../home/ScrollButton";
 function Header() {
   return (
     <header className="flex justify-center">
-      <nav className="mt-6 flex h-[190px] w-full items-center justify-between px-10 desktop:w-[1440px]">
+      <nav className="pt-6 flex h-[190px] w-full items-center justify-between px-10 desktop:w-[1440px]">
         <HamburgerMenu />
         <MainLogo />
         <CategoryBox />

--- a/frontend/src/components/home/CategoryBox.tsx
+++ b/frontend/src/components/home/CategoryBox.tsx
@@ -1,5 +1,7 @@
 // import { useState } from "react";
 
+import { useState } from "react";
+
 import { Category } from "@/types/categories";
 
 import CategoryHoberBox from "./CategoryHoberBox";
@@ -58,22 +60,26 @@ const categories: Category[] = [
 ];
 
 export default function CategoryBox() {
-  //FIXME: 페이지 이동시 state 유지 X, useContext 적용필요
-  // const [activeCategory, setActiveCategory] = useState("")
+  const[activeCategory, setActiveCategory] = useState("")
 
   return (
     <>
       <ul className="hidden gap-28 tablet:flex">
         {categories.slice(0, 3).map((category) => (
-          <li 
-          key={category.productId} 
-          className="group text-3xl font-bold" 
-          // onClick={() => setActiveCategory(category.name)}
-          >
-            <CategoryList name={category.name} />
-            {/* <CategoryUnderLine isVisible={activeCategory === category.name} /> */}
-            <CategoryUnderLine isVisible={false}/>
-            <CategoryHoberBox categories={categories.filter((sub)=> sub.parentId === category.productId)} />
+          <li key={category.productId} className="group text-3xl font-bold" onClick={()=> setActiveCategory(category.name)}>
+            <CategoryList
+              name={category.name}
+              categories={categories.filter(
+                (sub) => sub.parentId === category.productId,
+              )}
+            />
+            <CategoryUnderLine isVisible={activeCategory === category.name} />
+            {/* <CategoryUnderLine isVisible={false} /> */}
+            <CategoryHoberBox
+              categories={categories.filter(
+                (sub) => sub.parentId === category.productId,
+              )}
+            />
           </li>
         ))}
       </ul>

--- a/frontend/src/components/home/CategoryBox.tsx
+++ b/frontend/src/components/home/CategoryBox.tsx
@@ -64,7 +64,7 @@ export default function CategoryBox() {
 
   return (
     <>
-      <ul className="hidden gap-28 tablet:flex">
+      <ul className="hidden tablet:flex w-full max-w-[500px] tablet:justify-between">
         {categories.slice(0, 3).map((category) => (
           <li key={category.productId} className="group text-3xl font-bold" onClick={()=> setActiveCategory(category.name)}>
             <CategoryList

--- a/frontend/src/components/home/CategoryHoberBox.tsx
+++ b/frontend/src/components/home/CategoryHoberBox.tsx
@@ -12,7 +12,6 @@ export default function CategoryHoberBox({ categories }: Props) {
       {categories.map((category) => (
         <CategoryHoberList key={category.productId}
           name={category.name}
-          url={"/productlist"}
           alt={category.name}
           img={"/images/home/icon-" + category.name + ".png"}
         />

--- a/frontend/src/components/home/CategoryHoberList.tsx
+++ b/frontend/src/components/home/CategoryHoberList.tsx
@@ -1,20 +1,19 @@
+import { Link } from "react-router-dom";
 
 interface Props{
   name: string,
   img: string,
   alt: string,
-  url: string,
 }
 
 
-export default function CategoryHoberList({name, img, alt, url}: Props){
+export default function CategoryHoberList({name, img, alt}: Props){
   return (
     <>
-        <a href={url}>
-          <img src={img} alt={alt} className="rounded-xl hover:bg-gray-100" />
-          <p className="pt-2 text-center text-xs font-normal">{name}</p>
-        </a>
-      {/* <div className="h-16 w-[1px] bg-gray-200"></div> */}
+    <Link to={"/product_list/"+name}>
+      <img src={img} alt={alt} className="rounded-xl hover:bg-gray-100" />
+      <p className="pt-2 text-center text-xs font-normal">{name}</p>
+    </Link>
     </>
   );
 }

--- a/frontend/src/components/home/CategoryList.tsx
+++ b/frontend/src/components/home/CategoryList.tsx
@@ -1,11 +1,16 @@
+import { Link } from "react-router-dom";
+
+import { Category } from "@/types/categories";
+
 interface Props{
-  name: string
+  name: string,
+  categories: Category[],
 }
 
-export default function CategoryList({ name }: Props) {
+export default function CategoryList({ name, categories }: Props) {
   return (
-    <div className="flex justify-center">
-      {name}
-    </div>
+    <Link to={"/product_list/" + categories[0].name}>
+      <div className="flex justify-center">{name}</div>
+    </Link>
   );
 }

--- a/frontend/src/components/home/CategoryUnderline.tsx
+++ b/frontend/src/components/home/CategoryUnderline.tsx
@@ -2,7 +2,7 @@ export default function CategoryUnderLine( {isVisible} : {isVisible : boolean}){
   return (
     <img
       className={`pl-5 pr-6 group-hover:visible group-focus:visible ${isVisible ? "visible": "invisible"}`}
-      src="images/productlist/underline-menu.png"
+      src="/images/productlist/underline-menu.png"
     />
   );
 }

--- a/frontend/src/components/home/HamburgerMenu.tsx
+++ b/frontend/src/components/home/HamburgerMenu.tsx
@@ -1,3 +1,5 @@
+import HamburgerMenuList from "./HamburgerMenuList";
+
 interface Prop {
   isOpen: boolean;
   toggleMenu: () => void;
@@ -17,21 +19,14 @@ export default function HamburgerMenu({ isOpen, toggleMenu }: Prop) {
       </button>
       <div
         className={`${isOpen ? "block" : "hidden"} fixed inset-0 top-[190px] z-10 backdrop-brightness-50`}
+        onClick={toggleMenu}
       >
         <div className="h-full w-full">
           <ul className="flex h-[420px] flex-col items-center bg-white">
-            <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
-              WOMAN
-            </li>
-            <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
-              MAN
-            </li>
-            <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
-              ACC
-            </li>
-            <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
-              MY PAGE
-            </li>
+            <HamburgerMenuList url="/category_list/one-piece" >WOMAN</HamburgerMenuList>
+            <HamburgerMenuList url="/product_list/mid-length">MAN</HamburgerMenuList>
+            <HamburgerMenuList url="/category_list/bag">ACC</HamburgerMenuList>
+            <HamburgerMenuList url="/mypage">MY PAGE</HamburgerMenuList>
           </ul>
         </div>
       </div>

--- a/frontend/src/components/home/HamburgerMenu.tsx
+++ b/frontend/src/components/home/HamburgerMenu.tsx
@@ -1,21 +1,22 @@
-import { useState } from "react";
+interface Prop {
+  isOpen: boolean;
+  toggleMenu: () => void;
+}
 
-
-
-export default function HamburgerMenu() {
-  const [isOpen, setIsOpen] = useState(false);
+export default function HamburgerMenu({ isOpen, toggleMenu }: Prop) {
+  // const [isOpen, setIsOpen] = useState(false);
 
   return (
     <div className="relative tablet:hidden">
-      <button onClick={() => setIsOpen(!isOpen)}>
+      <button onClick={toggleMenu}>
         <img
           className="h-6 w-6"
           src="/images/home/button-hamburger.png"
           alt="햄버거 메뉴"
-          />
+        />
       </button>
       <div
-        className={`${isOpen ? "block" : "hidden"} fixed top-[190px] z-10 inset-0 backdrop-brightness-50`}
+        className={`${isOpen ? "block" : "hidden"} fixed inset-0 top-[190px] z-10 backdrop-brightness-50`}
       >
         <div className="h-full w-full">
           <ul className="flex h-[420px] flex-col items-center bg-white">

--- a/frontend/src/components/home/HamburgerMenu.tsx
+++ b/frontend/src/components/home/HamburgerMenu.tsx
@@ -1,31 +1,34 @@
-import { useState } from "react"
+import { useState } from "react";
 
-export default function HamburgerMenu(){
-  const[isOpen, setIsOpen] = useState(false)
-  
+
+
+export default function HamburgerMenu() {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <div className="relative tablet:hidden">
       <button onClick={() => setIsOpen(!isOpen)}>
         <img
           className="h-6 w-6"
           src="/images/home/button-hamburger.png"
-          alt=""
-        />
+          alt="햄버거 메뉴"
+          />
       </button>
-      {/* TODO: backdrop 효과 추가 */}
-      <div className={`absolute ${isOpen ? "block" : "hidden"} -translate-x-10 top-20 z-10`}>
-        <div className="h-[370px] w-screen bg-white">
-          <ul className="flex h-full flex-col items-center">
+      <div
+        className={`${isOpen ? "block" : "hidden"} fixed top-[190px] z-10 inset-0 backdrop-brightness-50`}
+      >
+        <div className="h-full w-full">
+          <ul className="flex h-[420px] flex-col items-center bg-white">
             <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
               WOMAN
             </li>
-            <li className="flex h-1/4 w-full items-center justify-center font-semibold">
+            <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
               MAN
             </li>
-            <li className="flex h-1/4 w-full items-center justify-center font-semibold">
+            <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
               ACC
             </li>
-            <li className="flex h-1/4 w-full items-center justify-center font-semibold">
+            <li className="flex h-1/4 w-full items-center justify-center font-semibold shadow-sm">
               MY PAGE
             </li>
           </ul>

--- a/frontend/src/components/home/HamburgerMenuList.tsx
+++ b/frontend/src/components/home/HamburgerMenuList.tsx
@@ -1,0 +1,19 @@
+import { Link } from "react-router-dom"
+
+interface Props{
+  url: string,
+  children: React.ReactNode
+}
+
+export default function HamburgerMenuList({url, children}: Props){
+  return(<>
+    <li className="flex h-1/4 w-full shadow-sm">
+      <Link
+        to={url}
+        className="flex h-full w-full items-center justify-center font-semibold"
+      >
+        {children}
+      </Link>
+    </li>
+  </>)
+}

--- a/frontend/src/components/home/MainLogo.tsx
+++ b/frontend/src/components/home/MainLogo.tsx
@@ -1,14 +1,15 @@
+import { Link } from "react-router-dom";
+
 const imgUrl: string = "/images/common/logo.png";
-const homeUrl: string = "/";
 
 export default function MainLogo(){
   return (
-    <a href={homeUrl}>
+    <Link to="/">
       <img
-        className="h-[106px] w-[106px] tablet:h-[190px] tablet:w-[190px]"
+        className="w-[106px] h-full tablet:w-[190px]"
         src={imgUrl}
         alt="로고 이미지"
       />
-    </a>
+    </Link>
   );
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,8 +2,8 @@ import "./styles/index.css";
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-
 import { RouterProvider } from "react-router-dom";
+
 import router from "./routes";
 
 createRoot(document.getElementById("root")!).render(

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { createBrowserRouter } from "react-router-dom";
 import App from "@/App";
 
 import ChangePwdCompletionPage from "./pages/ChangePwdCompletionPage";
+import ErrorPage from "./pages/ErrorPage";
 import Home from "./pages/HomePage";
 import JoinCompletionPage from "./pages/JoinCompletionPage";
 import JoinPage from "./pages/JoinPage";
@@ -31,6 +32,7 @@ const router = createBrowserRouter([
       },
       { path: "/paymentcompletionpage", element: <PayMentCompletionPage /> },
       { path: "/paymentorderpage", element: <PayMentOrderPage /> },
+      { path: "*", element: < ErrorPage/>}
     ],
   },
 ]);

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,18 +1,17 @@
 import { createBrowserRouter } from "react-router-dom";
 
-import ChangePwdCompletionPage from "./pages/ChangePwdCompletionPage";
+import App from "@/App";
 
+import ChangePwdCompletionPage from "./pages/ChangePwdCompletionPage";
+import Home from "./pages/HomePage";
+import JoinCompletionPage from "./pages/JoinCompletionPage";
 import JoinPage from "./pages/JoinPage";
 import LoginPage from "./pages/LoginPage";
-import JoinCompletionPage from "./pages/JoinCompletionPage";
-import PayMentCompletionPage from "./pages/PayMentCompletionPage";
 import MyPage from "./pages/MyPage";
-
+import PayMentCompletionPage from "./pages/PayMentCompletionPage";
+import PayMentOrderPage from "./pages/PayMentOrderPage";
 import ProductDetailPage from "./pages/ProductDetailPage";
 import ProductListPage from "./pages/ProductListPage";
-import PayMentOrderPage from "./pages/PayMentOrderPage";
-import App from "@/App";
-import Home from "./pages/HomePage";
 
 const router = createBrowserRouter([
   {

--- a/frontend/src/routes/pages/ErrorPage.tsx
+++ b/frontend/src/routes/pages/ErrorPage.tsx
@@ -1,0 +1,3 @@
+export default function ErrorPage(){
+  return <h1 className="font-extrabold text-center text-xl">잘못된 경로입니다.</h1>
+}


### PR DESCRIPTION
## 요약/키워드
1. 카테고리 링크 연결
- `Link` 사용, 메인 카테고리 클릭시 첫번째 세부 카테고리로 이동
- 햄버거 메뉴의 경우 `Link` 영역을 `w-full` 로 설정
- 잘못된 링크의 경우 오류 페이지로 연결 `path: "*"`
2. 햄버거 메뉴 수정
- 메인에서 햄버거 메뉴 오픈시 동영상배경이 아닌 흰배경이 나오도록 수정
- 햄버거 메뉴 오픈시에만 `fixed`로 설정
3. 헤더 반응형 수정
- 로고가 찌부되는 현상 수정: 기존 width, height를 모두 설정 -> width만 지정 h-full 로 수정