### PR TITLE
[신명희] 장바구니 불러오기 실패 시 에러 처리 및 장바구니 업데이트 시점 수정

### DIFF
--- a/frontend/src/components/cart/CartProductList.tsx
+++ b/frontend/src/components/cart/CartProductList.tsx
@@ -26,14 +26,20 @@ export default function CartProductList({
         <span className="inline-block w-1/3 text-right">가격</span>
       </div>
 
-      {cartListData.map((cartItem, index) => (
-        <CartProduct
-          key={index}
-          selectedSize={cartItem.size}
-          quantity={cartItem.quantity}
-          {...cartItem.Product}
-        />
-      ))}
+      {cartListData.length > 0 ? (
+        cartListData.map((cartItem, index) => (
+          <CartProduct
+            key={index}
+            selectedSize={cartItem.size}
+            quantity={cartItem.quantity}
+            {...cartItem.Product}
+          />
+        ))
+      ) : (
+        <div className="flex items-center justify-center">
+          아직 장바구니에 담긴 상품이 없습니다.
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/home/MainIconButton.tsx
+++ b/frontend/src/components/home/MainIconButton.tsx
@@ -34,7 +34,7 @@ export default function MainIconButton() {
       </button>
 
       <button className="relative">
-        <Link to="/cart">
+        <Link to={userId ? `/cart` : "/login"}>
           {cartCount > 0 && (
             <div className="absolute left-5 top-1 flex h-3 w-3 items-center justify-center rounded-full bg-red-600 text-[8px] text-white">
               {cartCount > 99 ? "99" : cartCount}

--- a/frontend/src/hooks/useCart.ts
+++ b/frontend/src/hooks/useCart.ts
@@ -16,8 +16,12 @@ function useCart() {
 
   const [cartListData, setCartListData] = useState<CartItem[]>([]);
 
+  const [updateCartTrigger, setUpdateCartTrigger] = useState(0);
+
   const handleCartListDataFetch = async () => {
     try {
+      if (!userId) return;
+
       const fetchedCartListData = await getCartListData(userId);
 
       if (!fetchedCartListData) {
@@ -32,7 +36,14 @@ function useCart() {
 
   const handleCartCountFetch = async () => {
     try {
+      if (!userId) return;
+
       const fetchedCartCount = await getCartCount(userId);
+      if (!fetchedCartCount) {
+        setCartCount(0);
+      } else {
+        setCartCount(fetchedCartCount);
+      }
       setCartCount(fetchedCartCount);
     } catch (error) {
       console.log(error);
@@ -43,8 +54,11 @@ function useCart() {
     const prevCount = cartCount;
 
     try {
+      if (!userId) return;
+
       await updateCartData(cartItem);
       setCartCount((prev) => prev + cartItem.quantity);
+      setUpdateCartTrigger((prev) => prev + 1);
     } catch (error) {
       setCartCount(prevCount);
       console.log(error);
@@ -62,7 +76,7 @@ function useCart() {
 
   useEffect(() => {
     handleCartCountFetch();
-  }, []);
+  }, [userId, updateCartTrigger]);
 
   return {
     cartListData,

--- a/frontend/src/hooks/useCart.ts
+++ b/frontend/src/hooks/useCart.ts
@@ -20,7 +20,11 @@ function useCart() {
     try {
       const fetchedCartListData = await getCartListData(userId);
 
-      setCartListData(fetchedCartListData);
+      if (!fetchedCartListData) {
+        setCartListData([]);
+      } else {
+        setCartListData(fetchedCartListData);
+      }
     } catch (error) {
       console.log(error);
     }


### PR DESCRIPTION
## 요약/키워드
1. 장바구니 불러오기 실패 시 에러 처리 
2. 장바구니 업데이트 시점 수정
3. 헤더의 장바구니 아이콘 누르면 로그인 사용자가 아닐 시 로그인 페이지로 이동
4. 장바구니에 담기 버튼 클릭시 로그인 사용자가 아닐 시 담겨지지 않도록 함 (알림도 추가할 예정)

### 중점적으로 리뷰받고 싶은 부분
- 일단 로그인 사용자가 아니거나, 백엔드에서 데이터가 제대로 불러오지 않을 경우를 각각 if문으로 에러 처리를 해주었는데 일반적으로 따로 에러 처리 모듈을 만드시는지, 어떻게 처리를 하는지 궁금합니다.
