### PR TITLE
[신명희] 상품 목록 페이지가 아닌 페이지에서 카테고리 물결 안 보이도록 하는 기능 로직 수정

### DIFF
--- a/frontend/src/components/home/CategoryBox.tsx
+++ b/frontend/src/components/home/CategoryBox.tsx
@@ -1,7 +1,7 @@
 import { Category } from "@/types/categories";
 import CategoryHoverBox from "./CategoryHoverBox";
 import CategoryUnderLine from "./CategoryUnderline";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 interface CategoryBoxProps {
   currentParentCategoryId: Category["parent_id"];
@@ -23,6 +23,8 @@ export default function CategoryBox({
 }: CategoryBoxProps) {
   if (parentCategories.length === 0) return;
 
+  const location = useLocation();
+
   return (
     <ul className="hidden w-full max-w-[500px] tablet:flex tablet:justify-between">
       {parentCategories.map((category: Category) => {
@@ -42,7 +44,10 @@ export default function CategoryBox({
               </div>
             </Link>
             <CategoryUnderLine
-              isVisible={currentParentCategoryId === category.id}
+              isVisible={
+                location.pathname.includes("product_list") &&
+                currentParentCategoryId === category.id
+              }
             />
             <CategoryHoverBox
               handleCurrentCategoryChange={handleCurrentCategoryChange}

--- a/frontend/src/hooks/useCategory.ts
+++ b/frontend/src/hooks/useCategory.ts
@@ -1,7 +1,6 @@
 import { CategoryContext } from "@/contexts/CategoryContext";
 import { getCategories } from "@/services/category";
 import { Category } from "@/types/categories";
-import { useLocation } from "react-router-dom";
 import { useContext, useEffect, useMemo } from "react";
 
 function useCategory() {
@@ -19,8 +18,6 @@ function useCategory() {
     currentCategoryId,
     setCurrentCategoryId,
   } = categoryContext;
-
-  const location = useLocation();
 
   const handleCategoryFetch = async () => {
     try {
@@ -66,12 +63,6 @@ function useCategory() {
   useEffect(() => {
     handleCategoryFetch();
   }, []);
-
-  useEffect(() => {
-    if (!location.pathname.includes("product_list")) {
-      setCurrentParentCategoryId(null);
-    }
-  }, [location]);
 
   return {
     currentCategoryId,


### PR DESCRIPTION
## 요약/키워드
1. 상품 목록 페이지가 아닌 페이지에서 카테고리 물결 안 보이도록 하는 기능 로직 수정
- 변경 전: 상품 목록 페이지를 벗어나면 현재 카테고리가 null이 되도록 힘
- 변경 후: 상품 목록 페이지를 벗어나면 물결 이미지를 조건부 렌더링 하여, 현재 카테고리 정보는 유지함