### PR TITLE
[반재영] 상품페이지 로딩 높이 수정

### DIFF
--- a/frontend/src/routes/pages/ProductDetailPage.tsx
+++ b/frontend/src/routes/pages/ProductDetailPage.tsx
@@ -23,7 +23,7 @@ function ProductDetailPage() {
   };
 
   if (!product) {
-    return <p className="mt-20 flex items-center justify-center">Loading...</p>; // 로딩 상태 처리
+    return <p className="mt-20 flex items-center justify-center h-screen">Loading...</p>; // 로딩 상태 처리
   }
 
   return (


### PR DESCRIPTION
## 요약/키워드
1. 상품페이지 로딩 높이 수정: 높이 지정이 안되어있어서 loading의 경우 푸터가 보이는 현상 -> h-screen 주어서 로딩페이지에서도 푸터가 보이지 않게 수정