### PR TITLE
[반재영] 회원정보 수정 입력폼 검증 수정, 회원정보수정 기능 추가, 마이페이지 접근성 수정

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -73,13 +73,11 @@ router.get('/email/:email', async (req, res) => {
 })
 
 // 특정 유저 수정
-router.put("/:id", async (req, res) => {
+router.patch("/:id", async (req, res) => {
   try {
-    const { name, nickname, age, id } = req.body;
-    // 요청 파라미터 검증
-    if (!name || !nickname || !age) {
-      next(Error(`missing required parameters`));
-    }
+    const id = req.params.id;
+    const { phoneNumber, password } = req.body;
+
 
     // 유저 존재 여부 확인
     const user = await User.findOne({ where: { id: id } });
@@ -88,8 +86,9 @@ router.put("/:id", async (req, res) => {
     }
 
     // 유저 있으면 수정
-    await User.update(
-      { name, nickname, age },
+    // update 성공시 1 반환, 실패시 0 반환
+    const result = await User.update(
+      { phoneNumber, password },
       {
         where: {
           id: id,
@@ -97,8 +96,12 @@ router.put("/:id", async (req, res) => {
       }
     );
 
-    const updatedUser = await User.findOne({ where: { id: id } });
-    res.json(updatedUser);
+    if(result[0] > 0){
+      const updatedUser = await User.findOne({where: {id: id}});
+      return res.json(updatedUser);
+    }else{
+      return res.status(400).json({ message: 'Update failed' })
+    }
   } catch (error) {
     console.log(error);
     res.status(500).json({ error: error.message });

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -47,7 +47,6 @@ export default function UserInfoEditForm() {
   const { userId } = useUserId();
   const [, setUser] = useState<User>();
 
-  // 1. Define your form.
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -83,16 +82,12 @@ export default function UserInfoEditForm() {
     fetchUserInfo();
   }, [form, userId]);
 
+  //회원정보 수정
   const navigate = useNavigate();
-  // 2. Define a submit handler.
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    // Do something with the form values.
-    // ✅ This will be type-safe and validated.
     try{
       const updateData = {phoneNumber: values.phoneNumber, password: values.password};
-      console.log(values);
-      const updatedUser = await updateUser(parseInt(userId), updateData)
-      console.log(updatedUser);
+      await updateUser(parseInt(userId), updateData);
       alert("수정 완료");
       navigate("/mypage");
     } catch(error){
@@ -223,10 +218,8 @@ export default function UserInfoEditForm() {
                 취소
               </CustomButton>
             </Link>
-            {/* TODO: 회원정보 수정 기능 추가 */}
             <PrimaryButton
               className="w-full"
-              // onClick={() => alert("준비 중인 기능입니다.")}
               type="submit"
             >
               확인

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -2,7 +2,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { z } from "zod";
 
 import {
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { useUserId } from "@/hooks/useUserId";
-import { getUser } from "@/services/user";
+import { getUser, updateUser } from "@/services/user";
 import { User } from "@/types/users";
 
 import PrimaryButton from "../common/PrimaryButton";
@@ -83,12 +83,22 @@ export default function UserInfoEditForm() {
     fetchUserInfo();
   }, [form, userId]);
 
-
+  const navigate = useNavigate();
   // 2. Define a submit handler.
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  async function onSubmit(values: z.infer<typeof formSchema>) {
     // Do something with the form values.
     // ✅ This will be type-safe and validated.
-    console.log(values);
+    try{
+      const updateData = {phoneNumber: values.phoneNumber, password: values.password};
+      console.log(values);
+      const updatedUser = await updateUser(parseInt(userId), updateData)
+      console.log(updatedUser);
+      alert("수정 완료");
+      navigate("/mypage");
+    } catch(error){
+      console.log(error)
+    }
+    
   }
 
   return (

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -8,7 +8,6 @@ import { z } from "zod";
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -26,8 +25,8 @@ const formSchema = z.object({
   username: z.string().min(2).max(10),
   phoneNumber: z
     .string()
-    .min(10, { message: "10자 이상이어야 합니다." })
-    .max(12),
+    .regex(/^(\d)$/, {message: "연락처는 숫자만 입력가능합니다."})
+    .regex(/^(\d{10,11})$/, {message: "연락처는 10자~11자 사이로 입력가능합니다."}),
   emailId: z.string().email(),
   password: z
     .string()
@@ -123,10 +122,12 @@ export default function UserInfoEditForm() {
                   <FormLabel className="flex w-1/3 items-center justify-start text-lg font-normal text-[#5E5E5E]">
                     연락처
                   </FormLabel>
-                  <FormControl className="h-12 w-2/3 border-none bg-[#F0F0F0]">
-                    <Input placeholder="010-1234-1234" {...field} />
-                  </FormControl>
-                  <FormMessage />
+                  <div className="w-2/3">
+                    <FormControl className="h-12 border-none bg-[#F0F0F0]">
+                      <Input placeholder="010-1234-1234" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </div>
                 </div>
               </FormItem>
             )}

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -33,9 +33,10 @@ const formSchema = z.object({
     .string()
     .min(8, { message: "8자 이상이어야 합니다." })
     .max(16, { message: "16자 이하여야 합니다." }),
-  address: z.string().optional(),
-  detailAddress: z.string().optional(),
-  passwordCheck: z.string().min(8).max(16),
+  passwordCheck: z
+    .string()
+    .min(8, { message: "비밀번호가 동일하지 않습니다." })
+    .max(16, { message: "비밀번호가 동일하지 않습니다." }),
 });
 
 export default function UserInfoEditForm() {
@@ -52,8 +53,6 @@ export default function UserInfoEditForm() {
       phoneNumber: "",
       emailId: "",
       password: "",
-      address: "",
-      detailAddress: "",
       passwordCheck: "",
     },
   });
@@ -197,8 +196,8 @@ export default function UserInfoEditForm() {
                     <FormDescription className="pt-1">
                       {passwordMessage}
                     </FormDescription>
+                    <FormMessage />
                   </div>
-                  <FormMessage />
                 </div>
               </FormItem>
             )}
@@ -224,8 +223,8 @@ export default function UserInfoEditForm() {
                     <FormDescription className="pt-1">
                       {passwordCheckMessage}
                     </FormDescription>
+                    <FormMessage />
                   </div>
-                  <FormMessage />
                 </div>
               </FormItem>
             )}
@@ -241,7 +240,8 @@ export default function UserInfoEditForm() {
             {/* TODO: 회원정보 수정 기능 추가 */}
             <PrimaryButton
               className="w-full"
-              onClick={() => alert("준비 중인 기능입니다.")}
+              // onClick={() => alert("준비 중인 기능입니다.")}
+              type="submit"
             >
               확인
             </PrimaryButton>

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -31,19 +31,23 @@ const formSchema = z.object({
   emailId: z.string().email(),
   password: z
     .string()
-    .min(8, { message: "8자 이상이어야 합니다." })
-    .max(16, { message: "16자 이하여야 합니다." }),
-  passwordCheck: z
-    .string()
-    .min(8, { message: "비밀번호가 동일하지 않습니다." })
-    .max(16, { message: "비밀번호가 동일하지 않습니다." }),
+    .regex(/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,16}$/, {
+      message: "영문, 숫자, 특수문자 포함 8자~16자 사이로 입력가능합니다.",
+    }),
+  passwordCheck: z.string()
+}).superRefine(({password, passwordCheck}, ctx) => {
+  if(password !== passwordCheck){
+    ctx.addIssue({
+      code: "custom",
+      message: "비밀번호가 일치하지 않습니다.",
+      path: ["passwordCheck"]
+    })
+  }
 });
 
 export default function UserInfoEditForm() {
   const { userId } = useUserId();
   const [, setUser] = useState<User>();
-  const [passwordMessage, setPasswordMessage] = useState("");
-  const [passwordCheckMessage, setPasswordCheckMessage] = useState("");
 
   // 1. Define your form.
   const form = useForm<z.infer<typeof formSchema>>({
@@ -77,32 +81,6 @@ export default function UserInfoEditForm() {
     fetchUserInfo();
   }, [form, userId]);
 
-  //비밀번호 검증
-  const password = form.watch("password");
-  const passwordCheck = form.watch("passwordCheck");
-  useEffect(() => {
-    if (password) {
-      const passwordRegex =
-        /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,16}$/;
-      if (!passwordRegex.test(password)) {
-        setPasswordMessage(
-          "영문, 숫자, 특수문자 포함 8자~16자 사이로 입력가능합니다.",
-        );
-      } else {
-        setPasswordMessage("");
-      }
-    } else {
-      setPasswordMessage(
-        "영문, 숫자, 특수문자 포함 8자~16자 사이로 입력가능합니다.",
-      );
-    }
-
-    if (passwordCheck && password !== passwordCheck) {
-      setPasswordCheckMessage("비밀번호가 동일하지 않습니다.");
-    } else {
-      setPasswordCheckMessage("");
-    }
-  }, [password, passwordCheck]);
 
   // 2. Define a submit handler.
   function onSubmit(values: z.infer<typeof formSchema>) {
@@ -189,13 +167,10 @@ export default function UserInfoEditForm() {
                     <FormControl className="h-12 border-none bg-[#F0F0F0]">
                       <Input
                         type="password"
-                        placeholder="password"
+                        placeholder="영문, 숫자, 특수문자 포함 8자~16자 사이로 입력가능합니다."
                         {...field}
                       />
                     </FormControl>
-                    <FormDescription className="pt-1">
-                      {passwordMessage}
-                    </FormDescription>
                     <FormMessage />
                   </div>
                 </div>
@@ -216,13 +191,10 @@ export default function UserInfoEditForm() {
                     <FormControl className="h-12 border-none bg-[#F0F0F0]">
                       <Input
                         type="password"
-                        placeholder="password"
+                        placeholder="영문, 숫자, 특수문자 포함 8자~16자 사이로 입력가능합니다."
                         {...field}
                       />
                     </FormControl>
-                    <FormDescription className="pt-1">
-                      {passwordCheckMessage}
-                    </FormDescription>
                     <FormMessage />
                   </div>
                 </div>

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -105,7 +105,7 @@ export default function UserInfoEditForm() {
                   <FormLabel className="flex w-1/3 items-center justify-start text-lg font-normal text-[#5E5E5E]">
                     이름
                   </FormLabel>
-                  <FormControl className="h-12 w-2/3 border-none bg-[#F0F0F0]">
+                  <FormControl className="h-12 w-2/3 border-none bg-[#F0F0F0] text-gray-500">
                     <Input placeholder="name" {...field} readOnly />
                   </FormControl>
                   <FormMessage />
@@ -141,7 +141,7 @@ export default function UserInfoEditForm() {
                   <FormLabel className="flex w-1/3 items-center justify-start text-lg font-normal text-[#5E5E5E]">
                     이메일 아이디
                   </FormLabel>
-                  <FormControl className="h-12 w-2/3 border-none bg-[#F0F0F0]">
+                  <FormControl className="h-12 w-2/3 border-none bg-[#F0F0F0] text-gray-500">
                     <Input
                       placeholder="swim360@google.com"
                       {...field}

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -2,7 +2,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { z } from "zod";
 
 import {
@@ -46,6 +46,9 @@ const formSchema = z.object({
 export default function UserInfoEditForm() {
   const { userId } = useUserId();
   const [, setUser] = useState<User>();
+  const location = useLocation();
+  const navigate = useNavigate();
+
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -57,10 +60,24 @@ export default function UserInfoEditForm() {
       passwordCheck: "",
     },
   });
+  
+  useEffect(()=> {
+    if (location.state !== "success") {
+      alert("잘못된 접근입니다.");
+      navigate("/mypage/verification");
+      return;
+    }
+    if (!userId) {
+      alert("잘못된 접근입니다.");
+      navigate("/login");
+      return;
+    }
+  }, [userId, location.state, navigate])
 
   //회원정보 불러오기
   useEffect(() => {
     const fetchUserInfo = async () => {
+      if(!userId) return;
       try {
         const user = await getUser(userId);
         setUser(user);
@@ -83,7 +100,6 @@ export default function UserInfoEditForm() {
   }, [form, userId]);
 
   //회원정보 수정
-  const navigate = useNavigate();
   async function onSubmit(values: z.infer<typeof formSchema>) {
     try{
       const updateData = {phoneNumber: values.phoneNumber, password: values.password};
@@ -92,6 +108,7 @@ export default function UserInfoEditForm() {
       navigate("/mypage");
     } catch(error){
       console.log(error)
+      alert("수정 중 오류가 발생했습니다.")
     }
     
   }

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -25,7 +25,6 @@ const formSchema = z.object({
   username: z.string().min(2).max(10),
   phoneNumber: z
     .string()
-    .regex(/^(\d)$/, {message: "연락처는 숫자만 입력가능합니다."})
     .regex(/^(\d{10,11})$/, {message: "연락처는 10자~11자 사이로 입력가능합니다."}),
   emailId: z.string().email(),
   password: z

--- a/frontend/src/components/mypage/UserInfoEditForm.tsx
+++ b/frontend/src/components/mypage/UserInfoEditForm.tsx
@@ -72,9 +72,13 @@ export default function UserInfoEditForm() {
           phoneNumber: user.phoneNumber || "",
           emailId: user.emailId || "",
         });
-      } catch (error: any) {
-        console.log("User Edit error: ", error);
-        alert(error.message);
+      } catch (error: unknown) {
+        if(error instanceof Error){
+          console.log("User Edit error: ", error);
+          alert(error.message);
+        }else{
+          alert("unexpected error")
+        }
       }
     };
     fetchUserInfo();

--- a/frontend/src/components/mypage/UserVerification.tsx
+++ b/frontend/src/components/mypage/UserVerification.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useUserId } from "@/hooks/useUserId";
@@ -10,6 +10,13 @@ export default function UserVerification() {
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
   const { userId } = useUserId();
+
+  useEffect(()=> {
+    if(!userId){
+      alert("잘못된 접근입니다.")
+      navigate("/login")
+    }
+  },[userId, navigate])
 
   const handlePassword = (event:React.ChangeEvent<HTMLInputElement>) => {
     setPassword(event.target.value);

--- a/frontend/src/components/mypage/UserVerification.tsx
+++ b/frontend/src/components/mypage/UserVerification.tsx
@@ -28,7 +28,7 @@ export default function UserVerification() {
 
       if (!user) return;
       if (user.password === password) {
-        navigate("/mypage/edit");
+        navigate("/mypage/edit", {state: "success"});
       } else {
         alert("비밀번호가 올바르지 않습니다.");
       }

--- a/frontend/src/routes/pages/MyPage.tsx
+++ b/frontend/src/routes/pages/MyPage.tsx
@@ -1,20 +1,23 @@
-import { useContext } from "react";
-import { Navigate } from "react-router-dom";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
 import LogoutButton from "@/components/mypage/LogoutButton";
 import OrderStatusPreview from "@/components/mypage/OrderStatusPreview";
 import RecentOrderPreview from "@/components/mypage/RecentOrderPreview";
 import UserDetailPreview from "@/components/mypage/UserDetailPreview";
 import UserInfoPreview from "@/components/mypage/UserInfoPreview";
-import { UserIdContext } from "@/contexts/UserIdContext";
+import { useUserId } from "@/hooks/useUserId";
 
 function MyPage() {
-  const userId = useContext(UserIdContext);
+  const { userId } = useUserId();
+  const navigate = useNavigate();
 
-  if (!userId) {
-    alert("로그인 정보가 정확하지 않습니다.");
-    return <Navigate to={"/login"} replace />;
-  }
+  useEffect(()=> {
+    if (!userId) {
+      alert("잘못된 접근입니다.");
+      navigate("/login");
+    }
+  }, [userId, navigate])
 
   return (
     <div className="mx-auto w-[90%] max-w-[1440px]">

--- a/frontend/src/routes/pages/PointAndReviewPage.tsx
+++ b/frontend/src/routes/pages/PointAndReviewPage.tsx
@@ -1,6 +1,20 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
 import PointAndReviewTab from "@/components/mypage/PointAndReview";
+import { useUserId } from "@/hooks/useUserId";
 
 export default function PointAndReviewPage() {
+  const { userId } = useUserId();
+  const navigate = useNavigate();
+
+  useEffect(()=>{
+    if(!userId){
+      alert("잘못된 접근입니다.");
+      navigate("/login");
+    }
+  },[userId, navigate])
+
   return (
     <div className="mx-auto w-full px-2 tablet:max-w-[1440px] tablet:px-20">
       <PointAndReviewTab />

--- a/frontend/src/services/user.ts
+++ b/frontend/src/services/user.ts
@@ -79,3 +79,15 @@ export async function getUserByEmail(userEmail: string): Promise<User> {
     throw new Error("로그인 중 에러가 발생했습니다. 잠시후 다시 시도해주세요.");
   }
 }
+
+export async function updateUser(userId: User['id'], updateData: {phoneNumber?: string, password: string}){
+  try{
+    const response = await axios.patch(`/users/${userId}`, updateData);
+    if(response.status === 400){
+      alert("회원정보를 수정하는데 실패했습니다.")
+    }
+    return response.data;
+  }catch(error){
+    console.log(error);
+  }
+}


### PR DESCRIPTION
## 요약/키워드
1. zod 를 통한 입력값 검증 및 오류 메세지 작성
- 정규식 사용하여 연락처와 비밀번호 형식 지정
- 비밀번호 확인의 경우 `superRefine`으로 값이 동일한지여부 검증
2. 회원정보 수정 기능 추가
- 수정가능한 값인 phoneNumber, password 데이터 전달
- `User.update`로 백엔드에서 db 수정, update 성공시 1 반환, 실패시 0 반환 -> 반환값에 따른 return 값 작성
- 회원정보 수정 성공시 마이페이지로 이동
3. FormMessage 위치 수정
4. 수정 불가능한 회원의 이름과 이메일아이디의 텍스트 색상 변경
5. `error: any` 타입오류 수정 -> `error:unknown`
6. 마이페이지 접근성 수정
- `/mypage`, `/mypage/verification`, `/mypage/point_and_review` 페이지 접근시 userId 확인
- `/mypage/edit` 접근시 `/mypage/verification`에서 전달된 state값과 userId 확인