### PR TITLE
[반재영] 메인 케러셀 탭인덱스 수정

### DIFF
--- a/frontend/src/components/home/BestPick.tsx
+++ b/frontend/src/components/home/BestPick.tsx
@@ -19,7 +19,7 @@ export default function BestPick() {
 
   return (
     <section className="flex h-full w-full flex-col items-center px-10 desktop:h-[845px] desktop:w-[1440px]">
-      <div className="text-center text-[26px] font-semibold">BEST PICK</div>
+      <div className="text-center text-[26px] font-semibold" tabIndex={0}>BEST PICK</div>
       <div className="mt-10 flex h-full w-full flex-col items-center gap-4 tablet:flex-row desktop:max-w-[1440px]">
         <div className="h-full w-full lg:w-1/2">
           <CarouselBestPick products={bestProducts} />

--- a/frontend/src/components/home/CarouselBanner.tsx
+++ b/frontend/src/components/home/CarouselBanner.tsx
@@ -61,6 +61,7 @@ export function CarouselBanner() {
       plugins={[plugin.current]}
       className="relative my-[86px] w-full desktop:w-[1440px]"
       onClick={plugin.current.stop}
+      tabIndex={0}
     >
       <CarouselContent>
         {banners.map((banner) => (

--- a/frontend/src/components/home/CarouselBestpick.tsx
+++ b/frontend/src/components/home/CarouselBestpick.tsx
@@ -33,9 +33,14 @@ export function CarouselBestPick({ products }: Props) {
             key={product.id}
             className="flex items-center justify-center"
           >
-            <Link to={`/product/${product.id}`}>
-              <div className="rounded-none border-none shadow-none">
-                <img src={product.imageUrl[0]} alt={product.name} />
+            <Link to={`/product/${product.id}`} tabIndex={-1}>
+              <div
+                className="rounded-none border-none shadow-none"
+              >
+                <img
+                  src={product.imageUrl[0]}
+                  alt={product.name}
+                />
               </div>
             </Link>
           </CarouselItem>

--- a/frontend/src/components/home/CarouselBestpick.tsx
+++ b/frontend/src/components/home/CarouselBestpick.tsx
@@ -26,6 +26,7 @@ export function CarouselBestPick({ products }: Props) {
       plugins={[plugin.current]}
       className="relative h-full w-full"
       onClick={plugin.current.stop}
+      tabIndex={0}
     >
       <CarouselContent>
         {products.map((product) => (

--- a/frontend/src/components/home/MainIconButton.tsx
+++ b/frontend/src/components/home/MainIconButton.tsx
@@ -28,14 +28,14 @@ export default function MainIconButton() {
     <div className="flex justify-around tablet:w-[190px]">
       <TooltipProvider delayDuration={200}>
         <Tooltip>
-          <TooltipTrigger>
+          <TooltipTrigger tabIndex={-1}>
             <Link to={userId ? "/mypage" : "/login"}>
               <img
                 className="hidden h-8 w-8 tablet:block"
                 src={myPageIcon.imgUrl}
                 alt={myPageIcon.name}
                 role="link"
-                tabIndex={0}
+                tabIndex={-1}
               />
             </Link>
           </TooltipTrigger>
@@ -49,7 +49,7 @@ export default function MainIconButton() {
 
       <TooltipProvider delayDuration={200}>
         <Tooltip>
-          <TooltipTrigger>
+          <TooltipTrigger tabIndex={-1}>
             <Link to={userId ? "/cart" : "/login"} className="relative">
               {cartCount > 0 && (
                 <div className="absolute left-[5px] top-1 flex h-3 w-3 items-center justify-center rounded-full bg-red-600 text-[8px] text-white">
@@ -61,7 +61,7 @@ export default function MainIconButton() {
                 src={cartIcon.imgUrl}
                 alt={cartIcon.name}
                 role="link"
-                tabIndex={0}
+                tabIndex={-1}
               />
             </Link>
           </TooltipTrigger>


### PR DESCRIPTION
## 요약/키워드
1. 베스트픽 케러셀에서 버튼에 탭이 가지않아도 다음 캐러셀 아이템으로 이동하는 문제
: 캐러셀 아이템에 탭인덱스 -1 적용, 캐러셀 컨테이너에 탭인덱스 0 적용
3. 헤더 마이페이지와 장바구니 아이콘의 탭인덱스가 여러번 선택되는 문제
: `TooltipTrigger`와 `img` 태그에 탭인덱스 -1 적용, `Link` 태그에만 탭인덱스 적용되도록 수정